### PR TITLE
Remove terraform commands

### DIFF
--- a/limber/__main__.py
+++ b/limber/__main__.py
@@ -69,9 +69,7 @@ def init():
     with open(provider_config,"w") as file:
         file.write(json.dumps(config, indent=4, sort_keys=False))
 
-    print(subprocess.call(["terraform", "init"], cwd="terraform_plan"))
-
-    print("Limber has now successfully initialized using your configuration using Terraform")
+    print("Limber has now successfully initialized using your configuration")
 
 t = terraform(folder="terraform_plan")
 
@@ -81,23 +79,6 @@ def plan():
     Create a plan for infra
     """
     t.create_terraform_configuration()
-    print(subprocess.call(["terraform", "plan"], cwd="terraform_plan"))
-
-@cli.command("apply")
-def apply():
-    print(subprocess.call(["terraform", "apply"], cwd="terraform_plan"))
-
-
-@cli.group()
-def terraform():
-    """
-    Commands related to Terraform
-    """
-
-@terraform.command("login")
-def login():
-    print("Using the Terraform CLI to login")
-    print(subprocess.call(["terraform", "login"]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Can't use it otherwise on github actions. Need to run the terraform init from the github actions terraform directly.