### PR TITLE
Fix cloud storage file hashes

### DIFF
--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -20,6 +20,8 @@ def test(arg):
     import pandas as pd
     from datetime import datetime
 
+    print("Test")
+
     df = pd.DataFrame([[datetime.now(), arg]], columns=["current_timestamp", "message"])
     df.to_gbq("test_dataset.test_table", if_exists="append")
 

--- a/dags/test_dag.py
+++ b/dags/test_dag.py
@@ -20,8 +20,6 @@ def test(arg):
     import pandas as pd
     from datetime import datetime
 
-    print("Test")
-
     df = pd.DataFrame([[datetime.now(), arg]], columns=["current_timestamp", "message"])
     df.to_gbq("test_dataset.test_table", if_exists="append")
 


### PR DESCRIPTION
Earlier the hash was appended to the file name with filename#hash, this made it so that each cloud storage object had to be updated all the time. Also, the hash varies because the zip files have different timestamps every time.

Now the hash is stable and only resources that actually change are updated.